### PR TITLE
Change internal handling of add_vertex! checks

### DIFF
--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -127,7 +127,7 @@ function Graphs.add_vertex!(meta_graph::MetaGraph, label, data)
     end
     nvnum = nv(meta_graph.graph)
     add_vertex!(meta_graph.graph)
-    added = nvnum != nv(meta_graph.graph)
+    added = nvnum + 1 == nv(meta_graph.graph)
     if added
         code = nv(meta_graph)
         meta_graph.vertex_labels[code] = label

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -125,7 +125,9 @@ function Graphs.add_vertex!(meta_graph::MetaGraph, label, data)
     if haskey(meta_graph, label)
         return false
     end
-    added = add_vertex!(meta_graph.graph)
+    nvnum = nv(meta_graph.graph)
+    add_vertex!(meta_graph.graph)
+    added = nvnum != nv(meta_graph.graph)
     if added
         code = nv(meta_graph)
         meta_graph.vertex_labels[code] = label


### PR DESCRIPTION
Related issue: https://github.com/JuliaGraphs/MetaGraphsNext.jl/issues/41

There was only one place where the result of `add_vertex!` was used as a check.