### PR TITLE
Prevent addition in underlying graph when dictionary operations failed

### DIFF
--- a/test/tutorial/1_basics.jl
+++ b/test/tutorial/1_basics.jl
@@ -30,6 +30,11 @@ colors[:red] = (255, 0, 0);
 colors[:green] = (0, 255, 0);
 colors[:blue] = (0, 0, 255);
 
+# Note that you cannot use labels or metadata that is incoherent with the types you specified at construction.
+
+@test_throws MethodError colors[:red] = "(255, 0, 0)"
+@test_throws MethodError colors["red"] = (255, 0, 0)
+
 # ### Edges
 
 # Use `setindex!` with two keys to add a new edge between the given labels and containing the given metadata. Beware that this time, nonexistent labels will throw an error.

--- a/test/tutorial/1_basics.jl
+++ b/test/tutorial/1_basics.jl
@@ -32,8 +32,8 @@ colors[:blue] = (0, 0, 255);
 
 # Note that you cannot use labels or metadata that is incoherent with the types you specified at construction.
 
-@test_throws MethodError colors[:red] = "(255, 0, 0)"
-@test_throws MethodError colors["red"] = (255, 0, 0)
+@test_throws MethodError colors[:red] = "(255, 0, 0)"  #src
+@test_throws MethodError colors["red"] = (255, 0, 0)  #src
 
 # ### Edges
 


### PR DESCRIPTION
Fixes #51 by switching the order of operations during vertex / edge addition: first dictionary updates, then modification of the underlying graph. If the dictionary updates throw a `MethodError` due to improper types, the underlying graph doesn't change