### PR TITLE
Add benchmark and remove warning for integer labels

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,10 +15,14 @@ julia = "1.6"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 JuliaFormatter = "98e50ef6-434e-11e9-1051-2b60c6c9e899"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
+SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Documenter", "JuliaFormatter", "MetaGraphs", "Test"]
+test = ["Aqua", "BenchmarkTools", "Documenter", "Graphs", "InteractiveUtils", "JuliaFormatter", "MetaGraphs", "SimpleTraits", "Test"]

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -2,7 +2,7 @@
 
 julia_version = "1.8.5"
 manifest_format = "2.0"
-project_hash = "580b7ffaff126fd1040a2c45d9e0166b2dd82fd9"
+project_hash = "087b8a4b471c678bd9311435ec9ae9ba1d7d5947"
 
 [[deps.ANSIColoredPrinters]]
 git-tree-sha1 = "574baf8110975760d391c710b6341da1afa48d8c"
@@ -24,6 +24,12 @@ uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
 
 [[deps.Base64]]
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.BenchmarkTools]]
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "d9a9701b899b30332bbcb3e1679c41cce81fb0e8"
+uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
+version = "1.3.2"
 
 [[deps.Compat]]
 deps = ["Dates", "LinearAlgebra", "UUIDs"]
@@ -212,6 +218,10 @@ version = "1.3.0"
 [[deps.Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
 [[deps.REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,6 +1,8 @@
 [deps]
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
+InteractiveUtils = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
 MetaGraphs = "626554b9-1ddb-594c-aa3c-2596fe9399a5"
 MetaGraphsNext = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"

--- a/src/MetaGraphsNext.jl
+++ b/src/MetaGraphsNext.jl
@@ -1,3 +1,8 @@
+"""
+    MetaGraphsNext
+
+A package for graphs with vertex labels and metadata in Julia. Its main export is the [`MetaGraph`](@ref) type.
+"""
 module MetaGraphsNext
 
 using JLD2

--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -13,7 +13,7 @@
 A graph type with custom vertex labels containing vertex-, edge- and graph-level metadata.
 
 Vertex labels have type `Label`, while vertex (resp. edge, resp. graph) metadata has type `VertexData` (resp. `EdgeData`, resp. `GraphData`).
-It is recommended not to set `Label` to an integer type, so as to avoid confusion between vertex labels and vertex codes (which have type `Code<:Integer`).
+It is recommended not to set `Label` to an integer type, so as to avoid confusion between vertex labels (which do not change as the graph evolves) and vertex codes (which have type `Code<:Integer` and can change as the graph evolves).
 
 # Fields
 - `graph::Graph`: underlying, data-less graph with vertex codes of type `Code`
@@ -73,9 +73,6 @@ function MetaGraph(
                 "For this MetaGraph constructor, the underlying graph should be empty."
             ),
         )
-    end
-    if Label <: Integer
-        @warn "Constructing a MetaGraph with integer labels is not advised."
     end
     vertex_labels = Dict{Code,Label}()
     vertex_properties = Dict{Label,Tuple{Code,VertexData}}()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -3,7 +3,6 @@ using Documenter
 using Graphs
 using JuliaFormatter
 using MetaGraphsNext
-using SimpleTraits
 using Test
 
 DocMeta.setdocmeta!(MetaGraphsNext, :DocTestSetup, :(using MetaGraphsNext); recursive=true)
@@ -30,6 +29,9 @@ DocMeta.setdocmeta!(MetaGraphsNext, :DocTestSetup, :(using MetaGraphsNext); recu
         end
         @testset verbose = true "Type stability" begin
             include(joinpath("tutorial", "4_type_stability.jl"))
+        end
+        @testset verbose = true "Benchmark" begin
+            include(joinpath("tutorial", "5_benchmark.jl"))
         end
     end
 

--- a/test/tutorial/2_graphs.jl
+++ b/test/tutorial/2_graphs.jl
@@ -2,7 +2,7 @@
 
 using Graphs
 using MetaGraphsNext
-using SimpleTraits
+using SimpleTraits  #src
 using Test  #src
 
 # `MetaGraph`s inherit many methods from Graphs.jl. In general, inherited methods refer to vertices by codes, not labels, for compatibility with the `AbstractGraph` interface.

--- a/test/tutorial/2_graphs.jl
+++ b/test/tutorial/2_graphs.jl
@@ -2,6 +2,7 @@
 
 using Graphs
 using MetaGraphsNext
+using SimpleTraits
 using Test  #src
 
 # `MetaGraph`s inherit many methods from Graphs.jl. In general, inherited methods refer to vertices by codes, not labels, for compatibility with the `AbstractGraph` interface.

--- a/test/tutorial/5_benchmark.jl
+++ b/test/tutorial/5_benchmark.jl
@@ -1,0 +1,120 @@
+# # Benchmark
+
+# Here we compare the performance of MetaGraphsNext.jl with its predecessor MetaGraphs.jl.
+
+using BenchmarkTools
+using Graphs
+using InteractiveUtils
+using MetaGraphs: MetaGraphs
+using MetaGraphsNext: MetaGraphsNext
+using Test  #src
+
+#=
+The benchmarking task is two-fold:
+1. Build a complete graph with random boolean metadata on the vertices (`active`) and float metadata on the edges (`distance`)
+2. Compute the sum of distances for all edges whose endpoints are both active.
+=#
+
+# ## Graph construction
+
+function build_incremental_metagraphsnext(n)
+    g = Graph(0)
+    mg = MetaGraphsNext.MetaGraph(
+        g;
+        label_type=Int,  # this will throw a warning
+        vertex_data_type=Bool,
+        edge_data_type=Float64,
+    )
+    for li in 1:n
+        mg[li] = rand(Bool)
+    end
+    for li in 1:n, lj in 1:(li - 1)
+        mg[li, lj] = rand(Float64)
+    end
+    return mg
+end;
+
+#-
+
+function build_bulk_metagraphsnext(n)
+    g = complete_graph(n)
+    vertices_description = [li => rand(Bool) for li in 1:n]
+    edges_description = [(li, lj) => rand(Float64) for li in 1:n for lj in 1:(li - 1)]
+    mg = MetaGraphsNext.MetaGraph(g, vertices_description, edges_description;)
+    return mg
+end;
+
+#-
+
+function build_metagraphs(n)
+    g = complete_graph(n)
+    mg = MetaGraphs.MetaGraph(g)
+    for i in 1:n
+        MetaGraphs.set_prop!(mg, i, :active, rand(Bool))
+    end
+    for i in 1:n, j in 1:(i - 1)
+        MetaGraphs.set_prop!(mg, i, j, :distance, rand(Float64))
+    end
+    return mg
+end;
+
+#-
+
+@btime build_incremental_metagraphsnext(100);
+
+#-
+
+@btime build_bulk_metagraphsnext(100);
+
+#-
+
+@btime build_metagraphs(100);
+
+# ## Graph exploitation
+
+function sum_active_edges_metagraphsnext(mg)
+    S = 0.0
+    for (li, lj) in MetaGraphsNext.edge_labels(mg)
+        active_i = mg[li]
+        active_j = mg[lj]
+        distance_ij = mg[li, lj]
+        if active_i && active_j
+            S += distance_ij
+        end
+    end
+    return S
+end
+
+#-
+
+function sum_active_edges_metagraphs(mg)
+    S = 0.0
+    for e in edges(mg)
+        i, j = src(e), dst(e)
+        active_i = MetaGraphs.get_prop(mg, i, :active)
+        active_j = MetaGraphs.get_prop(mg, j, :active)
+        distance_ij = MetaGraphs.get_prop(mg, i, j, :distance)
+        if active_i && active_j
+            S += distance_ij
+        end
+    end
+    return S
+end
+
+#-
+
+mg1 = build_incremental_metagraphsnext(100);
+@btime sum_active_edges_metagraphsnext($mg1);
+
+#-
+
+mg2 = build_metagraphs(100);
+@btime sum_active_edges_metagraphs($mg2);
+
+# The difference in performance can be explained by type instability.
+
+@code_warntype sum_active_edges_metagraphsnext(mg1);
+
+#-
+
+@code_warntype sum_active_edges_metagraphs(mg2);


### PR DESCRIPTION
- Add benchmark against MetaGraphs.jl for graph construction and exploitation (solve #31)
- Remove warning on integer labels for easier (repeated) construction when labels are irrelevant
- Fix test dependencies