### PR TITLE
induced_subgraph: new method based on a subset of edges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -8,9 +8,16 @@ JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
 SimpleTraits = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
 
 [compat]
+Aqua = "0.8"
+BenchmarkTools = "1"
+Documenter = "1"
 Graphs = "1.4.1"
+InteractiveUtils = "1"
 JLD2 = "0.1.11, 0.2, 0.3, 0.4"
+JuliaFormatter = "1"
+MetaGraphs = "0.7"
 SimpleTraits = "0.9"
+Test = "1"
 julia = "1.6"
 
 [extras]

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -44,6 +44,7 @@ function Graphs.outneighbors(meta_graph::MetaGraph, code::Integer)
 end
 
 function Base.issubset(meta_graph::MetaGraph, h::MetaGraph)
+    # no checking of: matching vertex label, or matching edge data
     return issubset(meta_graph.graph, h.graph)
 end
 
@@ -273,6 +274,23 @@ function Graphs.induced_subgraph(
     meta_graph::MetaGraph, vertex_codes::AbstractVector{<:Integer}
 )
     inducedgraph, code_map = induced_subgraph(meta_graph.graph, vertex_codes)
+    new_graph = MetaGraph(
+        inducedgraph,
+        empty(meta_graph.vertex_labels),
+        empty(meta_graph.vertex_properties),
+        empty(meta_graph.edge_data),
+        meta_graph.graph_data,
+        meta_graph.weight_function,
+        meta_graph.default_weight,
+    )
+    _copy_props!(meta_graph, new_graph, code_map)
+    return new_graph, code_map
+end
+
+function Graphs.induced_subgraph(
+    meta_graph::MetaGraph, edge_codes::AbstractVector{<:AbstractEdge}
+)
+    inducedgraph, code_map = induced_subgraph(meta_graph.graph, edge_codes)
     new_graph = MetaGraph(
         inducedgraph,
         empty(meta_graph.vertex_labels),

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -269,26 +269,10 @@ function Base.zero(meta_graph::MetaGraph)
 end
 
 function Graphs.induced_subgraph(
-    meta_graph::MetaGraph, vertex_codes::AbstractVector{<:Integer}
+    meta_graph::MetaGraph,
+    vertex_codes_or_edges::AbstractVector{<:Union{Integer,AbstractEdge}},
 )
-    inducedgraph, code_map = induced_subgraph(meta_graph.graph, vertex_codes)
-    new_graph = MetaGraph(
-        inducedgraph,
-        empty(meta_graph.vertex_labels),
-        empty(meta_graph.vertex_properties),
-        empty(meta_graph.edge_data),
-        meta_graph.graph_data,
-        meta_graph.weight_function,
-        meta_graph.default_weight,
-    )
-    _copy_props!(meta_graph, new_graph, code_map)
-    return new_graph, code_map
-end
-
-function Graphs.induced_subgraph(
-    meta_graph::MetaGraph, edge_codes::AbstractVector{<:AbstractEdge}
-)
-    inducedgraph, code_map = induced_subgraph(meta_graph.graph, edge_codes)
+    inducedgraph, code_map = induced_subgraph(meta_graph.graph, vertex_codes_or_edges)
     new_graph = MetaGraph(
         inducedgraph,
         empty(meta_graph.vertex_labels),

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -268,11 +268,8 @@ function Base.zero(meta_graph::MetaGraph)
     )
 end
 
-function Graphs.induced_subgraph(
-    meta_graph::MetaGraph,
-    vertex_codes_or_edges::AbstractVector{<:Union{Integer,AbstractEdge}},
-)
-    inducedgraph, code_map = induced_subgraph(meta_graph.graph, vertex_codes_or_edges)
+function meta_induced_subgraph(meta_graph::MetaGraph, selector)
+    inducedgraph, code_map = induced_subgraph(meta_graph.graph, selector)
     new_graph = MetaGraph(
         inducedgraph,
         empty(meta_graph.vertex_labels),
@@ -284,6 +281,19 @@ function Graphs.induced_subgraph(
     )
     _copy_props!(meta_graph, new_graph, code_map)
     return new_graph, code_map
+end
+
+function Graphs.induced_subgraph(
+    meta_graph::MetaGraph, vertex_codes::AbstractVector{<:Integer}
+)
+    return meta_induced_subgraph(meta_graph, vertex_codes)
+end
+
+function Graphs.induced_subgraph(
+    meta_graph::MetaGraph, edges::AbstractVector{<:AbstractEdge}
+)
+    # separate method to avoid dispatch ambiguity
+    return meta_induced_subgraph(meta_graph, edges)
 end
 
 @traitfn function Graphs.reverse(meta_graph::MG) where {MG <: MetaGraph; IsDirected{MG}}

--- a/test/tutorial/2_graphs.jl
+++ b/test/tutorial/2_graphs.jl
@@ -164,8 +164,8 @@ nv(rock_paper_scissors_subtree)
 # Checking that a graph is a subset of another is not supported yet. For example, an induced subgraph may appear as not a subset of the original graph, if vertex codes were modified.
 
 issubset(rock_paper_scissors_subtree, rock_paper_scissors)
-@test issubset(rock_paper_scissors_subtree, rock_paper_scissors) broken = true  #src
+@test_broken issubset(rock_paper_scissors_subtree, rock_paper_scissors)  #src
 #-
 rock_scissors, _ = induced_subgraph(rock_paper_scissors, [1, 3])
 issubset(rock_scissors, rock_paper_scissors)
-@test issubset(rock_scissors, rock_paper_scissors) broken = true  #src
+@test_broken issubset(rock_scissors, rock_paper_scissors)  #src

--- a/test/tutorial/2_graphs.jl
+++ b/test/tutorial/2_graphs.jl
@@ -133,7 +133,7 @@ haskey(rock_paper_scissors, :scissors, :rock)
 haskey(reverse(rock_paper_scissors), :scissors, :rock)
 @test haskey(reverse(rock_paper_scissors), :scissors, :rock)  #src
 
-# Finally, let us take a subgraph:
+# Let us take a subgraph induced by a subset of vertices:
 
 rock_paper, _ = induced_subgraph(rock_paper_scissors, [1, 2])
 @test @inferred induced_subgraph(rock_paper_scissors, [1, 2])[1] == rock_paper  #src
@@ -146,3 +146,25 @@ haskey(rock_paper, :paper, :rock)
 #-
 haskey(rock_paper, :rock, :scissors)
 @test !haskey(rock_paper, :rock, :scissors)  #src
+
+# Subgraphs can also be induced by a subset of edges.
+
+subtree_edges = collect(edges(rock_paper_scissors))[2:3]
+rock_paper_scissors_subtree, _ = induced_subgraph(rock_paper_scissors, subtree_edges)
+issubset(rock_paper_scissors_subtree, rock_paper_scissors)
+ne(rock_paper_scissors_subtree)
+@test ne(rock_paper_scissors_subtree) == 2  #src
+#-
+nv(rock_paper_scissors_subtree)
+@test nv(rock_paper_scissors_subtree) == 3  #src
+#-
+[rock_paper_scissors_subtree[e...] for e in edge_labels(rock_paper_scissors_subtree)]
+
+# Checking that a graph is a subset of another is not supported yet. For example, an induced subgraph may appear as not a subset of the original graph, if vertex codes were modified.
+
+issubset(rock_paper_scissors_subtree, rock_paper_scissors)
+@test issubset(rock_paper_scissors_subtree, rock_paper_scissors) broken = true  #src
+#-
+rock_scissors, _ = induced_subgraph(rock_paper_scissors, [1, 3])
+issubset(rock_scissors, rock_paper_scissors)
+@test issubset(rock_scissors, rock_paper_scissors) broken = true  #src


### PR DESCRIPTION
The package already has a method for an `induced_subgraph` based on a subset of nodes.
1. I added another method based on a subset of edges.
2. In the documentation, I added an example with an edge subset, next to the example based on a node subset.

While doing so, I noticed that `issubset` may have a bug, as an induced subgraph is not always a subset of the original graph. I added a sentence in the documentation warning users that `issubset` is not fully supported yet. The issue is not related to the new function: I added 2 examples, one of which is an induced subgraph from a subset of vertices.

I also noticed that `issubset` checks the relationship between the underlying graphs only, so I added comments inside the function to note that there's no check on the 2 graphs having consistent vertex labels or edge data.

I'm happy to remove everything about `issubset` from this PR. But then users following the package documentation may notice that the example induced subgraph is not a subset of its parent graph, and I wanted to be proactive about recognizing the issue.