### PR TITLE
Update tutorial on adding edges

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "MetaGraphsNext"
 uuid = "fa8bd995-216d-47f1-8a91-f3b68fbeb377"
-version = "0.7.0"
+version = "0.7.1"
 
 [deps]
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"

--- a/src/graphs.jl
+++ b/src/graphs.jl
@@ -189,7 +189,8 @@ Add an edge `(label_1, label_2)` to MetaGraph `meta_graph` with metadata `data`.
 If the `EdgeData` type of `meta_graph` is `Nothing`, `data` can be omitted.
 
 Return `true` if the edge has been added, `false` otherwise.
-If `(label_1, label_2)` already existed, its data is updated to `data` and `false` is returned nonetheless.
+If one of the labels does not exist, nothing happens and `false` is returned (the label is not inserted).
+If `(label_1, label_2)` already exists, its data is updated to `data` and `false` is returned nonetheless.
 """
 function Graphs.add_edge!(meta_graph::MetaGraph, label_1, label_2, data)
     if !haskey(meta_graph, label_1) || !haskey(meta_graph, label_2)

--- a/test/tutorial/1_basics.jl
+++ b/test/tutorial/1_basics.jl
@@ -39,7 +39,7 @@ colors[:blue] = (0, 0, 255);
 
 # ### Edges
 
-# Use `setindex!` with two keys to add a new edge between the given labels and containing the given metadata. Beware that this time, nonexistent labels will throw an error.
+# Use `setindex!` with two keys to add a new edge between the given labels and containing the given metadata. Beware that this time, an edge will only be added when both node labels already exist in the graph.
 
 colors[:red, :green] = :yellow;
 colors[:red, :blue] = :magenta;


### PR DESCRIPTION
Currently, the documentation states that an error will be thrown if edges are added using nonexistent labels, which is not true. The actual behavior is that it will just fail silently: the edge will not be added, and no error will be thrown.

Frankly, I think this behavior is very unintuitive and should be subject to change. In `networkx`, the nodes will be automatically added. At least we should update the documentation for now.