### PR TITLE
throw ArgumentError on transitiveclosure!(::MetaGraph)

### DIFF
--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -249,6 +249,6 @@ function label_for(meta_graph::MetaGraph, code::Integer)
     return meta_graph.vertex_labels[code]
 end
 
-function transitiveclosure!(meta_graph::MetaGraph, selflooped=false)
+function Graphs.transitiveclosure!(meta_graph::MetaGraph, selflooped=false)
     throw(ArgumentError("transitiveclosure! not implemented for type MetaGraph"))
 end

--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -248,3 +248,7 @@ This can be useful to interpret the results of methods inherited from `Graphs`. 
 function label_for(meta_graph::MetaGraph, code::Integer)
     return meta_graph.vertex_labels[code]
 end
+
+function transitiveclosure!(meta_graph::MetaGraph)
+    throw(ArgumentError("transitiveclosure! not implemented for type MetaGraph"))
+end

--- a/src/metagraph.jl
+++ b/src/metagraph.jl
@@ -249,6 +249,6 @@ function label_for(meta_graph::MetaGraph, code::Integer)
     return meta_graph.vertex_labels[code]
 end
 
-function transitiveclosure!(meta_graph::MetaGraph)
+function transitiveclosure!(meta_graph::MetaGraph, selflooped=false)
     throw(ArgumentError("transitiveclosure! not implemented for type MetaGraph"))
 end

--- a/test/misc.jl
+++ b/test/misc.jl
@@ -82,3 +82,10 @@ end
     (from, to) = first(edge_labels(graph))
     @test graph[from, to] === 1
 end
+
+@testset "No transitiveclosure! for MetaGraph" begin
+    graph = MetaGraph(
+        complete_graph(2), ["3" => nothing, "2" => nothing], [("3", "2") => 1]
+    )
+    @test_throws ArgumentError transitiveclosure!(graph)
+end


### PR DESCRIPTION
This is responsive to #89 

previously, this would not return an error but would not update the underlying graph structure.

Note: simply calling `transitiveclosure!(G.graph)` also fails as this does not update the metadata, e.g. `G.edge_data`.